### PR TITLE
Refactor main sections into modular partials

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,75 +33,10 @@
 <!--     <a href="#exp">Experience</a> &nbsp; / &nbsp; -->
 <!--     <a href="#service">Service</a> -->
   </div>
-  <div class="container" id="main">
-    <div class="row">
-      <div class="col-md-10 offset-md-2">
-        <div class="row" id="intro">
-          <div class="col-md-3">
-            <img src="assets/image.jpg" class="img-fluid rounded">
-          </div>
-          <div class="col-md-8 offset-md-1">
-            <h3>Daoyang Li</h3>
-            <br>
-            <p>daoyangl AT usc.edu</p>
-            <p>
-              
-                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" zoomAndPan="magnify" viewBox="0 0 30 30.000001" height="40" preserveAspectRatio="xMidYMid meet" version="1.0"><defs><clipPath id="id1"><path d="M 3.386719 3 L 27.339844 3 L 27.339844 28 L 3.386719 28 Z M 3.386719 3 " clip-rule="nonzero"/></clipPath></defs><g clip-path="url(#id1)"><path fill="rgb(0%, 0%, 0%)" d="M 14.660156 3.25 L 3.386719 10.308594 L 11.125 10.308594 C 11.097656 10.417969 11.050781 10.515625 11.027344 10.625 C 10.960938 10.964844 10.910156 11.34375 10.910156 11.734375 C 10.910156 16.773438 16.054688 16.207031 16.054688 16.207031 L 16.054688 17.492188 C 16.054688 18.011719 16.734375 17.832031 16.816406 18.890625 C 16.476562 18.890625 9.691406 18.695312 9.691406 23.277344 C 9.691406 27.882812 15.679688 27.65625 15.679688 27.65625 C 15.679688 27.65625 22.59375 27.964844 22.59375 22.273438 C 22.597656 18.871094 18.636719 17.765625 18.636719 16.398438 C 18.636719 15.015625 21.621094 14.609375 21.621094 11.375 C 21.621094 9.960938 21.523438 8.953125 20.890625 8.238281 C 20.84375 8.1875 20.808594 8.152344 20.761719 8.121094 C 20.75 8.109375 20.738281 8.101562 20.726562 8.09375 L 20.898438 8.09375 L 23.816406 5.902344 L 23.816406 8.898438 C 23.816406 8.953125 23.820312 9.007812 23.832031 9.0625 C 23.609375 9.1875 23.429688 9.363281 23.300781 9.585938 C 23.171875 9.808594 23.109375 10.050781 23.113281 10.308594 L 23.113281 11.722656 C 23.109375 11.910156 23.144531 12.09375 23.214844 12.269531 C 23.285156 12.445312 23.386719 12.597656 23.515625 12.734375 C 23.648438 12.867188 23.804688 12.972656 23.976562 13.042969 C 24.152344 13.117188 24.332031 13.152344 24.519531 13.152344 C 24.710938 13.152344 24.890625 13.117188 25.066406 13.042969 C 25.238281 12.972656 25.390625 12.867188 25.523438 12.734375 C 25.65625 12.597656 25.757812 12.445312 25.828125 12.269531 C 25.898438 12.09375 25.933594 11.910156 25.929688 11.722656 L 25.929688 10.308594 C 25.933594 10.050781 25.871094 9.808594 25.742188 9.585938 C 25.613281 9.363281 25.433594 9.1875 25.207031 9.0625 C 25.21875 9.007812 25.226562 8.953125 25.226562 8.898438 L 25.226562 4.839844 L 27.339844 3.25 Z M 15.632812 7.5625 C 16.039062 7.542969 16.445312 7.640625 16.835938 7.863281 C 17.125 8.007812 17.402344 8.21875 17.644531 8.480469 C 18.148438 8.984375 18.570312 9.714844 18.796875 10.578125 C 19.332031 12.625 18.636719 14.597656 17.191406 14.96875 C 15.765625 15.375 14.171875 14.039062 13.621094 12.007812 C 13.378906 11.015625 13.410156 10.054688 13.6875 9.292969 C 13.691406 9.28125 13.695312 9.273438 13.699219 9.265625 C 13.703125 9.261719 13.710938 9.257812 13.714844 9.253906 C 13.792969 8.953125 13.921875 8.679688 14.082031 8.457031 C 14.371094 8.035156 14.753906 7.746094 15.226562 7.617188 C 15.363281 7.585938 15.496094 7.566406 15.632812 7.5625 Z M 16.183594 19.75 C 18.566406 19.570312 20.597656 20.886719 20.746094 22.675781 C 20.84375 24.449219 19.007812 26.027344 16.605469 26.1875 C 14.222656 26.351562 12.160156 25.050781 12.046875 23.277344 C 11.933594 21.492188 13.78125 19.929688 16.183594 19.75 Z M 16.183594 19.75 " fill-opacity="1" fill-rule="nonzero"/></g></svg>
-                <a href="https://scholar.google.com/citations?user=-QfTPqgAAAAJ&hl=en&authuser=1" target="_blank">Google Scholar</a>
-<!--                · 
-              
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16"> <path d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"/> </svg>
-                <a href="https://twitter.com/DaoyangLi" target="_blank">Twitter</a> -->
-              
-            </p>
-<!--             <p>
-              
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16"> <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/> </svg>
-                <a href="https://github.com/daoyangl" target="_blank">GitHub</a>
-               ·
-              
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-linkedin" viewBox="0 0 16 16"> <path d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z"/> </svg>
-                <a href="https://www.linkedin.com/in/daoyang-li-a60780259/" target="_blank">LinkedIn</a>
-              
-            </p> -->
-          </div>
-        </div>
-        <div class="row" id="about" style="padding-top: 40px;">
-          <div class="col-md-10">
-            <p>Hi there! I am currently a Master's student in Spatial Data Science at the <a href="https://www.usc.edu/", target="_blank">University of Southern California</a>. I earned my Bachelor's degree in Data Science and Big Data Technology from <a href="https://www.muc.edu.cn/" target="_blank">Minzu University of China</a>.</p>
-
-            <p>My research interests revolve around the <strong>explainability</strong> and <strong>interpretability</strong> of <Strong>Large Language Models</Strong>. I’m particularly focused on understanding how these models make decisions and ensuring transparency in their outputs. Beyond that, I’m also passionate about applying AI to solve real-world problems, especially in areas like <strong>traffic systems</strong> and <strong>spatial data science</strong>.</p>
-
-            <p>By blending strong theoretical foundations with real-world applications, I aim to make AI not only smarter but also more understandable and impactful in practical settings.</p>
-            </div>
-        </div>
-
+  <div data-include="sections/bio.html"></div>
 
 <!--         news -->
 <!--         <div class="row" id="news" style="padding-top: 0px;">
-          <div class="col-md-10">
-            <div><strong>📌 Pinned</strong>
-              <ul>
-                <li>Check our newly released <strong style="color: red;">Amazon Reviews 2023</strong> dataset! <a href="https://amazon-reviews-2023.github.io/" target="_blank">[🌐 Webpage]</a> <a href="https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023" target="_blank">[🤗 HF datasets]</a><br> The new dataset features up-to-date reviews (up to Sep. 2023) and larger sizes (570M reviews, 48M items, and 60B tokens).</li>
-              </ul>
-            </div>
-            <div><strong>📣 News:</strong></div>
-            <div style="background-color: #EBF5FB; height: 120px; overflow-y: scroll;">
-              <ul>
-                <li>[Mar 09, 2024] <a href="https://github.com/RUCAIBox/LC-Rec" target="_blank">LC-Rec</a> has been accepted at ICDE'24! With <strong>only ~1000 new tokens</strong> and instruction tuning, 🦙 LLaMA-7B will be a powerful 😈 generative recommender, and efficiently rank ground-truth items over ~20k candidates. Congratulations to Bowen!! 🎉</li>
-                <li>[Mar 06, 2024] Releasing Amazon Reviews 2023 dataset <a href="https://amazon-reviews-2023.github.io/" target="_blank">[link]</a>! The new dataset features up-to-date reviews (up to Sep. 2023) and larger sizes (2-3 times larger in #reviews, #items, and #tokens). Check the <a href="https://twitter.com/yupenghou97/status/1765899738279534609">X (twitter) post</a> for more details.</li>
-                <li>[Jan 22, 2024] AgentCF is accepted as a full paper at WWW'24 (acc. 20.2%)! We simulate both users and items in recommender systems using LLM agents. Aligning w/ real interaction data, AgentCF can inject collaborative information into the whole agent system. Congrats to Junjie!! 🎉</li>
-                <li>[Dec 14, 2023] <a href="https://github.com/RUCAIBox/LLMRank" target="_blank">LLMRank</a>, a paper about interesting findings on LLM & RecSys is accepted as a full paper at ECIR'24 (acceptance rate 23%). Good news at the end of the year! 🎄</li>
-                <li>[Jul 26, 2023] Co-organizing <a href="https://sites.google.com/view/pgai2023" target="_blank">Personalized Generative AI</a> @ CIKM'23. Call for Paper until Sep 10, 2023. LLMs & RecSys, LLM-Powered Agents, Personalized LLMs, etc. are highly welcomed!</li>
-                <li>[Jun 21, 2023] Our paper "Reciprocal Sequential Recommendation" is accepted as a full paper at RecSys'23 (acceptance rate 18.7%). Congrats to Bowen!! 🎉</li>
-                <li>[Jan 25, 2023] One paper about pre-training transferable recommendation models is accepted as a full paper at WWW'23 (acceptance rate 19.2%).</li>
-                <li>[Oct 19, 2022] Our CIKM'22 paper "RecBole 2.0: Towards a More Up-to-Date Recommendation Library" receives <i style="color: red;">Best Resource Paper Runner-up</i>.</li>
-                <li>[Sep 19, 2022] Our RecSys'22 paper "Modeling Two-Way Selection Preference for Person-Job Fit" receives <i style="color: red;">Best Student Paper Runner-up</i>.</li>
-                <li>[Aug 31, 2022] One paper about graph learning privacy is accepted as a full paper by ICDM'22 (acceptance rate 9.77%).</li>
-              </ul>
-            </div>
-          </div>
-        </div> -->
 
         
 <!--         open source -->
@@ -135,177 +70,11 @@
 
 
 <!--   publications -->
-        <div class="row" id="pub">
-          <div class="col-md-10">
-            <h4>Publications</h4>
-<!--             <h4>Publications <a href="full_pub.html">[Full]</a></h4> -->
-            <div class="split"></div>
-            <i style="color: #777777;">† denotes equal contribution</i><br><br>
-
-            
-<!--             <h5>2024</h5>
-            <ul>
-              <li>
-                <p><strong>Multi-Behavior Generative Recommendation.</strong></p>
-                <p>Zihan Liu†, <strong>Yupeng Hou</strong>†, Julian McAuley.</p>
-                <p>
-                  <span>CIKM 2024</span>
-                  [<a href="https://arxiv.org/pdf/2405.16871" target="_blank">paper</a>]
-                  [<a href="https://github.com/anananan116/MBGen" target="_blank">code</a>]
-                  [<a href="#" data-toggle="collapse" data-target="#liu2024mbgen">bib</a>]
-                  <div id="liu2024mbgen" class="collapse in">
-                    <br>
-                    <pre>
-@inproceedings{liu2024mbgen,
-  title={Multi-Behavior Generative Recommendation},
-  author={Zihan Liu and Yupeng Hou and Julian McAuley},
-  booktitle={{CIKM}},
-  year={2024}
-}
-                    </pre>
-                  </div>
-                </p>
-              </li>
-            </ul> -->
-
-            <h5>2025</h5>
-            <ul>
-              <li>
-                <p><strong>LMR-BENCH: Evaluating LLM Agent’s Ability on Reproducing Language Modeling Research</strong></p>
-                <p>Shuo Yan, Ziming Luo, Zimu Wang, Ruochen Li, <strong>Daoyang Li</strong>, Liqiang Jing, Kaiyu He, Peilin Wu, Juntong Ni, George Michalopoulos, Yue Zhang, Ziyang Zhang, Mian Zhang, Zhiyu Chen, Xinya Du</p>
-                <p>
-                  <span>Preprint</span>
-                </p>
-              </li>
-              
-              <li>
-                <p><strong>Hyperlocal disaster damage assessment using bi-temporal street-view imagery and pre-trained vision models</strong></p>
-                <p>Yifan Yang, Lei Zou, Bing Zhou, <strong>Daoyang Li</strong>, Binbin Lin, Joynal Abedin, Mingzheng Yang</p>
-                <p>
-                  <span>Preprint</span>
-                  [<a href="https://arxiv.org/abs/2504.09066" target="_blank">paper</a>]
-                  [<a href="#" data-toggle="collapse" data-target="#yang2025hyperlocaldisasterdamageassessment">bib</a>]
-                  <div id="yang2025hyperlocaldisasterdamageassessment" class="collapse in">
-                    <br>
-                    <pre>
-@misc{yang2025hyperlocaldisasterdamageassessment,
-      title={Hyperlocal disaster damage assessment using bi-temporal street-view imagery and pre-trained vision models}, 
-      author={Yifan Yang and Lei Zou and Bing Zhou and Daoyang Li and Binbin Lin and Joynal Abedin and Mingzheng Yang},
-      year={2025},
-      eprint={2504.09066},
-      archivePrefix={arXiv},
-      primaryClass={cs.CV},
-      url={https://arxiv.org/abs/2504.09066}, 
-}
-                    </pre>
-                  </div>
-                </p>
-              </li>
-              
-              <li>
-                <p><strong>Exploring and Mitigating Knowledge Biases in LLMs for Linguistic Uncertainty Interpretation</strong></p>
-                <p>Quan Zhang*, <strong>Daoyang Li</strong>*, Xinya Du</p>
-              </li>
-            </ul>
-
-            
-            <h5>2024</h5>
-            <ul>
-              <li>
-                <p><strong>Exploring Multilingual Probing in Large Language Models: A Cross-Language Analysis</strong></p>
-                <p><strong><em>Daoyang Li</em></strong> and Mingyu Jin and Qingcheng Zeng and Haiyan Zhao and Mengnan Du</p>
-                <p>
-                  <span>ACL Workshop</span>
-                  [<a href="https://arxiv.org/abs/2409.14459" target="_blank">paper</a>]
-                  [<a href="#" data-toggle="collapse" data-target="#li2024exploringmultilingualprobinglarge">bib</a>]
-                  <div id="li2024exploringmultilingualprobinglarge" class="collapse in">
-                    <br>
-                    <pre>
-@misc{li2024exploringmultilingualprobinglarge,
-      title={Exploring Multilingual Probing in Large Language Models: A Cross-Language Analysis}, 
-      author={Daoyang Li and Mingyu Jin and Qingcheng Zeng and Haiyan Zhao and Mengnan Du},
-      year={2024},
-      eprint={2409.14459},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2409.14459} }
-                    </pre>
-                  </div>
-                </p>
-              </li>
-              <li>
-                <p><strong>GeoLocator: A Location-Integrated Large Multimodal Model (LMM) for Inferring Geo-Privacy</strong></p>
-                <p>Yifan Yang, Siqin Wang, <strong><em>Daoyang Li</em></strong>, Shuju Sun, Qingyang Wu</p>
-                <p>
-                  <span>Applied Sciences</span>
-                  [<a href="https://www.mdpi.com/2076-3417/14/16/7091" target="_blank">paper</a>]
-                  [<a href="#" data-toggle="collapse" data-target="#Yang_2024">bib</a>]
-                  <div id="Yang_2024" class="collapse in">
-                    <br>
-                    <pre>
-@article{Yang_2024,
-   title={GeoLocator: A Location-Integrated Large Multimodal Model (LMM) for Inferring Geo-Privacy},
-   volume={14},
-   ISSN={2076-3417},
-   url={http://dx.doi.org/10.3390/app14167091},
-   DOI={10.3390/app14167091},
-   number={16},
-   journal={Applied Sciences},
-   publisher={MDPI AG},
-   author={Yang, Yifan and Wang, Siqin and Li, Daoyang and Sun, Shuju and Wu, Qingyang},
-   year={2024},
-   month=aug, pages={7091} }
-                    </pre>
-                  </div>
-<!--                   <i style="font-size: smaller;">Most influential WWW'23 paper (Rank #1) highlighted by Paper Digest Team. <a href="https://www.paperdigest.org/2023/09/most-influential-www-papers-2023-09/" target="_blank">(2023-09)</a> <a href="https://www.paperdigest.org/2024/05/most-influential-www-papers-2024-05/" target="_blank">(2024-05)</a></i> -->
-                </p>
-              </li>
-            </ul>
-            
-            
-          </div>
-        </div>
+        <div data-include="sections/publications.html"></div>
         
   
 <!--   education -->
-        <div class="row" id="edu">
-          <div class="col-md-10">
-            <h4>Education</h4>
-            <div class="split"></div>
-            <ul>
-              <li>
-                <div class="row" style="padding-top:0%">
-                  <div class="col-10">
-                    <strong>University of Southern California</strong>
-                    <p>
-                      2022 - 2024,
-                      <a href="https://viterbischool.usc.edu/" target="_blank">Viterbi School of Engineering</a><br><br>
-<!--                       Advisor : <a href="https://dornsife.usc.edu/spatial/profile/siqin-sisi-wang/" target="_blank">Prof. Siqin (Sisi) Wang</a> -->
-                    </p>
-                  </div>
-                  <div class="col-2">
-                    <img src="assets/usc.png" style="height: 4em">
-                  </div>
-                </div>
-              </li>
-              <li>
-                <div class="row" style="padding-top:0%">
-                  <div class="col-10">
-                    <strong>Minzu University of China</strong>
-                    <p>
-                      2018 - 2022,
-                      <a href="https://xingong.muc.edu.cn/" target="_blank">School of Information Engineering</a><br><br>
-<!--                       Advisor : <a href="https://xingong.muc.edu.cn/info/1051/1149.htm" target="_blank">Prof. Yutong Zheng</a> -->
-                    </p>
-                  </div>
-                  <div class="col-2">
-                    <img src="assets/muc.png" style="height: 4em">
-                  </div>
-                </div>
-              </li>
-            </ul>
-          </div>
-        </div>
+        <div data-include="sections/education.html"></div>
 
   
 <!--         experience -->
@@ -416,12 +185,6 @@
             </ul>
           </div>
         </div> -->
-
-
-  
-      </div>
-    </div>
-  </div>
   <div class="container" id="tail">
     <div class="row">
       <div class="col-md-12">

--- a/js/script.js
+++ b/js/script.js
@@ -1,10 +1,47 @@
-window.onscroll = function() {scrollFunction()};
-
 function scrollFunction() {
   var navbar = document.getElementById("nav");
+  if (!navbar) {
+    return;
+  }
+
   if (document.body.scrollTop > 280 || document.documentElement.scrollTop > 280) {
     navbar.style.opacity = "1";
   } else {
     navbar.style.opacity = "0";
   }
 }
+
+function includeHTML() {
+  var includeElements = Array.prototype.slice.call(document.querySelectorAll('[data-include]'));
+  var includePromises = includeElements.map(function(element) {
+    var file = element.getAttribute('data-include');
+    if (!file) {
+      return Promise.resolve();
+    }
+
+    return fetch(file)
+      .then(function(response) {
+        if (!response.ok) {
+          throw new Error('Unable to load ' + file + ': ' + response.status + ' ' + response.statusText);
+        }
+        return response.text();
+      })
+      .then(function(data) {
+        element.innerHTML = data;
+      })
+      .catch(function(error) {
+        console.error(error);
+        element.innerHTML = '<p class="text-danger">Unable to load ' + file + '.</p>';
+      });
+  });
+
+  return Promise.all(includePromises);
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  includeHTML().then(function() {
+    scrollFunction();
+  });
+});
+
+window.addEventListener('scroll', scrollFunction);

--- a/sections/bio.html
+++ b/sections/bio.html
@@ -1,0 +1,29 @@
+<div class="container" id="main">
+  <div class="row">
+    <div class="col-md-10 offset-md-2">
+      <div class="row" id="intro">
+        <div class="col-md-3">
+          <img src="assets/image.jpg" class="img-fluid rounded">
+        </div>
+        <div class="col-md-8 offset-md-1">
+          <h3>Daoyang Li</h3>
+          <br>
+          <p>daoyangl AT usc.edu</p>
+          <p>
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" zoomAndPan="magnify" viewBox="0 0 30 30.000001" height="40" preserveAspectRatio="xMidYMid meet" version="1.0"><defs><clipPath id="id1"><path d="M 3.386719 3 L 27.339844 3 L 27.339844 28 L 3.386719 28 Z M 3.386719 3 " clip-rule="nonzero"/></clipPath></defs><g clip-path="url(#id1)"><path fill="rgb(0%, 0%, 0%)" d="M 14.660156 3.25 L 3.386719 10.308594 L 11.125 10.308594 C 11.097656 10.417969 11.050781 10.515625 11.027344 10.625 C 10.960938 10.964844 10.910156 11.34375 10.910156 11.734375 C 10.910156 16.773438 16.054688 16.207031 16.054688 16.207031 L 16.054688 17.492188 C 16.054688 18.011719 16.734375 17.832031 16.816406 18.890625 C 16.476562 18.890625 9.691406 18.695312 9.691406 23.277344 C 9.691406 27.882812 15.679688 27.65625 15.679688 27.65625 C 15.679688 27.65625 22.59375 27.964844 22.59375 22.273438 C 22.597656 18.871094 18.636719 17.765625 18.636719 16.398438 C 18.636719 15.015625 21.621094 14.609375 21.621094 11.375 C 21.621094 9.960938 21.523438 8.953125 20.890625 8.238281 C 20.84375 8.1875 20.808594 8.152344 20.761719 8.121094 C 20.75 8.109375 20.738281 8.101562 20.726562 8.09375 L 20.898438 8.09375 L 23.816406 5.902344 L 23.816406 8.898438 C 23.816406 8.953125 23.820312 9.007812 23.832031 9.0625 C 23.609375 9.1875 23.429688 9.363281 23.300781 9.585938 C 23.171875 9.808594 23.109375 10.050781 23.113281 10.308594 L 23.113281 11.722656 C 23.109375 11.910156 23.144531 12.09375 23.214844 12.269531 C 23.285156 12.445312 23.386719 12.597656 23.515625 12.734375 C 23.648438 12.867188 23.804688 12.972656 23.976562 13.042969 C 24.152344 13.117188 24.332031 13.152344 24.519531 13.152344 C 24.710938 13.152344 24.890625 13.117188 25.066406 13.042969 C 25.238281 12.972656 25.390625 12.867188 25.523438 12.734375 C 25.65625 12.597656 25.757812 12.445312 25.828125 12.269531 C 25.898438 12.09375 25.933594 11.910156 25.929688 11.722656 L 25.929688 10.308594 C 25.933594 10.050781 25.871094 9.808594 25.742188 9.585938 C 25.613281 9.363281 25.433594 9.1875 25.207031 9.0625 C 25.21875 9.007812 25.226562 8.953125 25.226562 8.898438 L 25.226562 4.839844 L 27.339844 3.25 Z M 15.632812 7.5625 C 16.039062 7.542969 16.445312 7.640625 16.835938 7.863281 C 17.125 8.007812 17.402344 8.21875 17.644531 8.480469 C 18.148438 8.984375 18.570312 9.714844 18.796875 10.578125 C 19.332031 12.625 18.636719 14.597656 17.191406 14.96875 C 15.765625 15.375 14.171875 14.039062 13.621094 12.007812 C 13.378906 11.015625 13.410156 10.054688 13.6875 9.292969 C 13.691406 9.28125 13.695312 9.273438 13.699219 9.265625 C 13.703125 9.261719 13.710938 9.257812 13.714844 9.253906 C 13.792969 8.953125 13.921875 8.679688 14.082031 8.457031 C 14.371094 8.035156 14.753906 7.746094 15.226562 7.617188 C 15.363281 7.585938 15.496094 7.566406 15.632812 7.5625 Z M 16.183594 19.75 C 18.566406 19.570312 20.597656 20.886719 20.746094 22.675781 C 20.84375 24.449219 19.007812 26.027344 16.605469 26.1875 C 14.222656 26.351562 12.160156 25.050781 12.046875 23.277344 C 11.933594 21.492188 13.78125 19.929688 16.183594 19.75 Z M 16.183594 19.75 " fill-opacity="1" fill-rule="nonzero"/></g></svg>
+            <a href="https://scholar.google.com/citations?user=-QfTPqgAAAAJ&hl=en&authuser=1" target="_blank">Google Scholar</a>
+          </p>
+        </div>
+      </div>
+      <div class="row" id="about" style="padding-top: 40px;">
+        <div class="col-md-10">
+          <p>Hi there! I am currently a Master's student in Spatial Data Science at the <a href="https://www.usc.edu/" target="_blank">University of Southern California</a>. I earned my Bachelor's degree in Data Science and Big Data Technology from <a href="https://www.muc.edu.cn/" target="_blank">Minzu University of China</a>.</p>
+
+          <p>My research interests revolve around the <strong>explainability</strong> and <strong>interpretability</strong> of <Strong>Large Language Models</Strong>. I’m particularly focused on understanding how these models make decisions and ensuring transparency in their outputs. Beyond that, I’m also passionate about applying AI to solve real-world problems, especially in areas like <strong>traffic systems</strong> and <strong>spatial data science</strong>.</p>
+
+          <p>By blending strong theoretical foundations with real-world applications, I aim to make AI not only smarter but also more understandable and impactful in practical settings.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/sections/education.html
+++ b/sections/education.html
@@ -1,0 +1,36 @@
+<div class="row" id="edu">
+  <div class="col-md-10">
+    <h4>Education</h4>
+    <div class="split"></div>
+    <ul>
+      <li>
+        <div class="row" style="padding-top:0%">
+          <div class="col-10">
+            <strong>University of Southern California</strong>
+            <p>
+              2022 - 2024,
+              <a href="https://viterbischool.usc.edu/" target="_blank">Viterbi School of Engineering</a><br><br>
+            </p>
+          </div>
+          <div class="col-2">
+            <img src="assets/usc.png" style="height: 4em">
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="row" style="padding-top:0%">
+          <div class="col-10">
+            <strong>Minzu University of China</strong>
+            <p>
+              2018 - 2022,
+              <a href="https://xingong.muc.edu.cn/" target="_blank">School of Information Engineering</a><br><br>
+            </p>
+          </div>
+          <div class="col-2">
+            <img src="assets/muc.png" style="height: 4em">
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/sections/publications.html
+++ b/sections/publications.html
@@ -1,0 +1,99 @@
+<div class="row" id="pub">
+  <div class="col-md-10">
+    <h4>Publications</h4>
+    <div class="split"></div>
+    <i style="color: #777777;">† denotes equal contribution</i><br><br>
+
+    <h5>2025</h5>
+    <ul>
+      <li>
+        <p><strong>LMR-BENCH: Evaluating LLM Agent’s Ability on Reproducing Language Modeling Research</strong></p>
+        <p>Shuo Yan, Ziming Luo, Zimu Wang, Ruochen Li, <strong>Daoyang Li</strong>, Liqiang Jing, Kaiyu He, Peilin Wu, Juntong Ni, George Michalopoulos, Yue Zhang, Ziyang Zhang, Mian Zhang, Zhiyu Chen, Xinya Du</p>
+        <p>
+          <span>Preprint</span>
+        </p>
+      </li>
+
+      <li>
+        <p><strong>Hyperlocal disaster damage assessment using bi-temporal street-view imagery and pre-trained vision models</strong></p>
+        <p>Yifan Yang, Lei Zou, Bing Zhou, <strong>Daoyang Li</strong>, Binbin Lin, Joynal Abedin, Mingzheng Yang</p>
+        <p>
+          <span>Preprint</span>
+          [<a href="https://arxiv.org/abs/2504.09066" target="_blank">paper</a>]
+          [<a href="#" data-toggle="collapse" data-target="#yang2025hyperlocaldisasterdamageassessment">bib</a>]
+          <div id="yang2025hyperlocaldisasterdamageassessment" class="collapse in">
+            <br>
+            <pre>
+@misc{yang2025hyperlocaldisasterdamageassessment,
+      title={Hyperlocal disaster damage assessment using bi-temporal street-view imagery and pre-trained vision models},
+      author={Yifan Yang and Lei Zou and Bing Zhou and Daoyang Li and Binbin Lin and Joynal Abedin and Mingzheng Yang},
+      year={2025},
+      eprint={2504.09066},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV},
+      url={https://arxiv.org/abs/2504.09066},
+}
+            </pre>
+          </div>
+        </p>
+      </li>
+
+      <li>
+        <p><strong>Exploring and Mitigating Knowledge Biases in LLMs for Linguistic Uncertainty Interpretation</strong></p>
+        <p>Quan Zhang*, <strong>Daoyang Li</strong>*, Xinya Du</p>
+      </li>
+    </ul>
+
+    <h5>2024</h5>
+    <ul>
+      <li>
+        <p><strong>Exploring Multilingual Probing in Large Language Models: A Cross-Language Analysis</strong></p>
+        <p><strong><em>Daoyang Li</em></strong> and Mingyu Jin and Qingcheng Zeng and Haiyan Zhao and Mengnan Du</p>
+        <p>
+          <span>ACL Workshop</span>
+          [<a href="https://arxiv.org/abs/2409.14459" target="_blank">paper</a>]
+          [<a href="#" data-toggle="collapse" data-target="#li2024exploringmultilingualprobinglarge">bib</a>]
+          <div id="li2024exploringmultilingualprobinglarge" class="collapse in">
+            <br>
+            <pre>
+@misc{li2024exploringmultilingualprobinglarge,
+      title={Exploring Multilingual Probing in Large Language Models: A Cross-Language Analysis},
+      author={Daoyang Li and Mingyu Jin and Qingcheng Zeng and Haiyan Zhao and Mengnan Du},
+      year={2024},
+      eprint={2409.14459},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2409.14459} }
+            </pre>
+          </div>
+        </p>
+      </li>
+      <li>
+        <p><strong>GeoLocator: A Location-Integrated Large Multimodal Model (LMM) for Inferring Geo-Privacy</strong></p>
+        <p>Yifan Yang, Siqin Wang, <strong><em>Daoyang Li</em></strong>, Shuju Sun, Qingyang Wu</p>
+        <p>
+          <span>Applied Sciences</span>
+          [<a href="https://www.mdpi.com/2076-3417/14/16/7091" target="_blank">paper</a>]
+          [<a href="#" data-toggle="collapse" data-target="#Yang_2024">bib</a>]
+          <div id="Yang_2024" class="collapse in">
+            <br>
+            <pre>
+@article{Yang_2024,
+   title={GeoLocator: A Location-Integrated Large Multimodal Model (LMM) for Inferring Geo-Privacy},
+   volume={14},
+   ISSN={2076-3417},
+   url={http://dx.doi.org/10.3390/app14167091},
+   DOI={10.3390/app14167091},
+   number={16},
+   journal={Applied Sciences},
+   publisher={MDPI AG},
+   author={Yang, Yifan and Wang, Siqin and Li, Daoyang and Sun, Shuju and Wu, Qingyang},
+   year={2024},
+   month=aug, pages={7091} }
+            </pre>
+          </div>
+        </p>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- extract the bio, publications, and education markup into new partial files under `sections/`
- update `index.html` to include the partials so each section can be edited independently
- enhance the site script to fetch the partial files and keep the navbar scroll behaviour intact

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d8384b96e483269a8e1b814a52a123