### PR TITLE
Adjust education/experience spacing

### DIFF
--- a/components/education.html
+++ b/components/education.html
@@ -9,8 +9,8 @@
           <div class="col-10">
             <strong>University of Southern California</strong>
             <p>
-              2022 - 2024,
-              <a href="https://viterbischool.usc.edu/" target="_blank">Viterbi School of Engineering</a><br><br>
+              2022 - 2024,<br>
+              <a href="https://viterbischool.usc.edu/" target="_blank">Viterbi School of Engineering</a>
             </p>
           </div>
           <div class="col-2">
@@ -23,8 +23,8 @@
           <div class="col-10">
             <strong>Minzu University of China</strong>
             <p>
-              2018 - 2022,
-              <a href="https://xingong.muc.edu.cn/" target="_blank">School of Information Engineering</a><br><br>
+              2018 - 2022,<br>
+              <a href="https://xingong.muc.edu.cn/" target="_blank">School of Information Engineering</a>
             </p>
           </div>
           <div class="col-2">

--- a/components/experience.html
+++ b/components/experience.html
@@ -1,6 +1,6 @@
 
 <!-- Experience Section -->
-<div class="row" id="edu">
+<div class="row" id="exp">
   <div class="col-md-10">
     <h4>Experience</h4>
     <div class="split"></div>
@@ -10,8 +10,8 @@
           <div class="col-10">
             <strong>University of Southern California</strong>
             <p>
-              2022 - 2024,
-              <a href="https://viterbischool.usc.edu/" target="_blank">Viterbi School of Engineering</a><br><br>
+              2022 - 2024,<br>
+              <a href="https://viterbischool.usc.edu/" target="_blank">Viterbi School of Engineering</a>
             </p>
           </div>
           <div class="col-2">
@@ -24,8 +24,8 @@
           <div class="col-10">
             <strong>Minzu University of China</strong>
             <p>
-              2018 - 2022,
-              <a href="https://xingong.muc.edu.cn/" target="_blank">School of Information Engineering</a><br><br>
+              2018 - 2022,<br>
+              <a href="https://xingong.muc.edu.cn/" target="_blank">School of Information Engineering</a>
             </p>
           </div>
           <div class="col-2">


### PR DESCRIPTION
## Summary
- remove extra line breaks from the education and experience entries to eliminate excess whitespace between sections
- correct the experience section id so the navigation anchor scrolls to the right place

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d8814227548326aa463666b998398a